### PR TITLE
Bugfix: changed dict key 'order_time_in_force' to just 'time_in_force…

### DIFF
--- a/tradehub/authenticated_client.py
+++ b/tradehub/authenticated_client.py
@@ -64,7 +64,7 @@ class AuthenticatedClient(TradehubPublicClient):
             fee_dict = fee
         else:
             fee_type = self.get_transaction_fee_type(transaction_type)
-            fee_amount = self.fees[fee_type] * len(messages)
+            fee_amount = str(int(self.fees[fee_type]) * len(messages))
             fee_dict = {
                 "amount": [{"amount": fee_amount, "denom": "swth"}],
                 "gas": self.gas,
@@ -127,7 +127,7 @@ class AuthenticatedClient(TradehubPublicClient):
                      fee: dict = None):     # JS original -> msgs: ConcreteMsg[], options: any = {}
 
         if (not sequence and self.account_sequence_nbr is None) or self.account_nbr is None or self.account_nbr == '0':  # no sequence override, get latest from blockchain
-            self.account_blockchain_dict = self.get_account()
+            self.account_blockchain_dict = self.get_account(self.wallet.address)
             self.account_nbr = self.account_blockchain_dict["result"]["value"]["account_number"]
             self.account_sequence_nbr = self.account_blockchain_dict["result"]["value"]["sequence"]
             if self.account_nbr == '0' or self.account_nbr is None:

--- a/tradehub/types.py
+++ b/tradehub/types.py
@@ -116,7 +116,7 @@ class CreateOrderMessage:
     quantity: str
     price: str = None
     type: str = 'limit'               # Order Type
-    order_time_in_force: str = None
+    time_in_force: str = None
     stop_price: str = None
     trigger_type: str = None
     is_post_only: bool = False


### PR DESCRIPTION
Bugfix: changed dict key 'order_time_in_force' to just 'time_in_force' otherwise the order can not executed. Error message indicated wrong chain id or sequence which is really missleading.
Bugfix: multiplier for more than just 1 message multiplied the string not the actual number, fixed that.
Bugfix: if an account has no sequence number there was a request without provided swth address.