### PR TITLE
Feature/edit order

### DIFF
--- a/tradehub/authenticated_client.py
+++ b/tradehub/authenticated_client.py
@@ -243,6 +243,13 @@ class AuthenticatedClient(TradehubPublicClient):
         transaction_type = "CANCEL_ALL_MSG_TYPE"
         return self.submit_transaction_on_chain(messages = [message], transaction_type = transaction_type, fee = fee)
 
+    def edit_order(self, message: types.EditOrderMessage, fee: dict = None):
+        return self.edit_orders(messages = [message], fee = fee)
+
+    def edit_orders(self, messages: [types.EditOrderMessage], fee: dict = None):
+        transaction_type = "EDIT_ORDER_MSG_TYPE"
+        return self.submit_transaction_on_chain(messages = messages, transaction_type = transaction_type, fee = fee)
+
     def stake_switcheo(self, message = types.DelegateTokensMessage, fee: dict = None):
         transaction_type = "DELEGATE_TOKENS_MSG_TYPE"
         message.amount.amount = to_tradehub_asset_amount(amount = float(message.amount.amount), decimals = self.tokens["swth"]["decimals"])

--- a/tradehub/types.py
+++ b/tradehub/types.py
@@ -153,6 +153,14 @@ class DelegateTokensMessage:
     amount: DelegateTokensAmount
 
 @dataclass
+class EditOrderMessage:
+    id: str
+    quantity: str = None
+    price: str = None
+    stop_price: str = None
+    originator: str = None
+
+@dataclass
 class WithdrawDelegatorRewardsMessage:
     delegator_address: str
     validator_address: str


### PR DESCRIPTION
Adding the ability to edit orders throughout the API. Tested with the following code.

```
print(dmx.edit_limit_order(order_id="", quantity="235"))
print(dmx.edit_stop_order(order_id="", quantity="235"))
edit_order_msg_1 = types.EditOrderMessage(id="", quantity="225", price="0.0000175")
edit_order_msg_2 = types.EditOrderMessage(id="", quantity="220", stop_price="0.0000175")
edit_order_msgs = [edit_order_msg_1, edit_order_msg_2]
print(dmx.edit_orders(orders=edit_order_msgs))
```