### PR TITLE
Node Crawler v2 and Testing Utility Functions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,6 +38,8 @@ jobs:
         python -m poetry run python -m pip install pytest pytest-cov
 
     - name: Test with pytest
+      env:
+        WEB3_API_KEY: ${{ secrets.ALCHEMY_WEB3_API_KEY }}
       run: |
         python -m poetry run python -m pytest -v tests/ --cov=./ --cov-report=xml
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,5 +38,7 @@ jobs:
         python -m poetry run python -m pip install pytest pytest-cov
 
     - name: Test with pytest
+      env:
+        WEB3_API_KEY: ${{ secrets.ALCHEMY_WEB3_API_KEY }}
       run: |
         python -m poetry run python -m pytest -v tests/ --cov=./ --cov-report=xml

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,6 +38,8 @@ jobs:
         python -m poetry run python -m pip install pytest pytest-cov
 
     - name: Test with pytest
+      env:
+        WEB3_API_KEY: ${{ secrets.ALCHEMY_WEB3_API_KEY }}
       run: |
         python -m poetry run python -m pytest -v tests/ --cov=./ --cov-report=xml
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,7 +21,6 @@ ETH_ADDRESS = '0x32c46323b51c977814e05ef5e258ee4da0e4c3c3'   # Ropsten Testnet A
 ETH_CONTRACT = '0x0025b3342582d106454e88ecb091f3e456f81ac3'  # Sushi Ropsten Testnet Contract
 
 WEB3_API_KEY = os.environ.get('WEB3_API_KEY')
-WEB3_API_KEY = 'kZLcvbGCS-TWPgYB451-kIvHzU_8hVxb'
 WEB3_API_URL = 'https://eth-ropsten.alchemyapi.io/v2/{}'.format(WEB3_API_KEY)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,10 @@
+import os
 from unittest import TestCase
-import random
 
-from tradehub.utils import validator_crawler_mp
+from tradehub.decentralized_client import TradehubNodeClient
 
-active_peers = validator_crawler_mp(network='main')["active_peers"]
-validator_ip = active_peers[random.randint(a=0, b=len(active_peers)-1)]
-DEVEL_AND_CO_SENTRY = validator_ip
+active_node_client = TradehubNodeClient(network='mainnet')
+DEVEL_AND_CO_SENTRY = active_node_client.active_sentry_api_ip
 
 WALLET_VALIDATOR = "swth1vwges9p847l9csj8ehrlgzajhmt4fcq4sd7gzl"
 WALLET_DEVEL = "swth1qlue2pat9cxx2s5xqrv0ashs475n9va963h4hz"
@@ -15,6 +14,15 @@ WALLET_MNEMONIC = "refuse flag merge fiction choose dream frown gauge need fabri
 WALLET_PRIVATE_KEY = b'\x15\xcf\xdd\xdf\xead\x88\xd2y!\xdb\xb61\xa6\x98\xeeQm\x05\xed\x8d%43!\n\xccS\xcbsf\x90'
 WALLET_PUBLIC_KEY = b'\x02o\x1f\xfbL\x96\xe8\x1e\xb0\x12V\x80\xc7t\xfc\xb40R\xaeu\xf3{\xf6\xd7m]\xd1\xa9\x91\xa8\xe0Df'
 WALLET_ADDRESS = 'tswth1upcgussnx4p3jegwj3x2fccwlajwckkzgstrp8'
+
+NEO_ADDRESS = 'APuP9GsSCPJKrexPe49afDV8CQYubZGWd8'
+NEO_CONTRACT = '3e09e602eeeb401a2fec8e8ea137d59aae54a139'
+ETH_ADDRESS = '0x32c46323b51c977814e05ef5e258ee4da0e4c3c3'   # Ropsten Testnet Address
+ETH_CONTRACT = '0x0025b3342582d106454e88ecb091f3e456f81ac3'  # Sushi Ropsten Testnet Contract
+
+WEB3_API_KEY = os.environ.get('WEB3_API_KEY')
+WEB3_API_KEY = 'kZLcvbGCS-TWPgYB451-kIvHzU_8hVxb'
+WEB3_API_URL = 'https://eth-ropsten.alchemyapi.io/v2/{}'.format(WEB3_API_KEY)
 
 
 class APITestCase(TestCase):

--- a/tests/test_tradehub_decentralized_client.py
+++ b/tests/test_tradehub_decentralized_client.py
@@ -1,0 +1,163 @@
+from tradehub.decentralized_client import TradehubNodeClient
+from tests import APITestCase
+
+
+class TestTradeHubNodeClient(APITestCase):
+
+    def setUp(self) -> None:
+        self.tradehub_client = TradehubNodeClient(network='mainnet')
+
+    def test_validator_crawler_mp(self):
+        self.tradehub_client.validator_crawler_mp()
+        self.assertIsNotNone(self.tradehub_client.active_sentry_api_list)
+        self.assertIsNotNone(self.tradehub_client.active_validator_list)
+
+    def test_validator_status_request(self):
+        expect: dict = {
+            'moniker': str,
+            'id': str,
+            'ip': str,
+            'version': str,
+            'network': str,
+            'latest_block_hash': str,
+            'latest_block_height': str,
+            'latest_block_time': str,
+            'earliest_block_height': str,
+            'earliest_block_time': str,
+            'catching_up': bool,
+            'validator_address': str,
+            'validator_pub_key_type': str,
+            'validator_pub_key': str,
+            'validator_voting_power': str,
+            'validator_status': str,
+            'connected_nodes': [{
+                'node_id': str,
+                'node_ip': str,
+                'node_full': str,
+            }]
+        }
+
+        result = self.tradehub_client.validator_status_request(validator_ip=self.tradehub_client.active_sentry_api_ip)
+        self.assertDictStructure(expect, result)
+
+    def test_parse_validator_status(self):
+        expect: dict = {
+            'moniker': str,
+            'id': str,
+            'ip': str,
+            'version': str,
+            'network': str,
+            'latest_block_hash': str,
+            'latest_block_height': str,
+            'latest_block_time': str,
+            'earliest_block_height': str,
+            'earliest_block_time': str,
+            'catching_up': bool,
+            'validator_address': str,
+            'validator_pub_key_type': str,
+            'validator_pub_key': str,
+            'validator_voting_power': str,
+        }
+
+        validator_status_json: dict = {
+            'jsonrpc': '2.0',
+            'id': -1,
+            'result': {
+                'node_info': {
+                    'protocol_version': {
+                        'p2p': '7',
+                        'block': '10',
+                        'app': '0'
+                    },
+                    'id': '756dece3e0a00705c61a7de701f78f51f5e9a91b',
+                    'listen_addr': 'tcp://0.0.0.0:26656',
+                    'network': 'switcheo-tradehub-1',
+                    'version': '0.33.7',
+                    'channels': '4020212223303800',
+                    'moniker': 'pike',
+                    'other': {
+                        'tx_index': 'on',
+                        'rpc_address': 'tcp://0.0.0.0:26659'
+                    }
+                },
+                'sync_info': {
+                    'latest_block_hash': '3E385BDDF88024B1767BC5E19D4C4F92122FDF16BF93702CCACBD5D1E2299252',
+                    'latest_app_hash': '0470CC9EA15482ECB5D497A6D70EF9C1181B649244AB589D8858941FB65EC7FB',
+                    'latest_block_height': '7559634',
+                    'latest_block_time': '2021-02-16T07:25:24.602077456Z',
+                    'earliest_block_hash': 'B4AF1F3D3D3FD5795BDDB7A6A2E6CA4E34D06338505D6EC46DD8F99E72ADCDAB',
+                    'earliest_app_hash': '',
+                    'earliest_block_height': '1',
+                    'earliest_block_time': '2020-08-14T07:32:27.856700491Z',
+                    'catching_up': False
+                },
+                'validator_info': {
+                    'address': 'A84B0CB22673DCBCEC8C9EB0A2E83AAC8DE297A2',
+                    'pub_key': {
+                        'type': 'tendermint/PubKeyEd25519',
+                        'value': 'qjqeC/G3OABg7RVbtGDOAS0nWAy3AheJaI7s7OPb5o0='
+                    },
+                    'voting_power': '0'
+                }
+            }
+        }
+
+        result = self.tradehub_client.parse_validator_status(request_json=validator_status_json, validator_ip=self.tradehub_client.active_sentry_api_ip)
+        self.assertDictStructure(expect, result)
+
+    def test_sentry_status_request(self):
+        self.tradehub_client.sentry_status_request()
+        self.assertIsNotNone(self.tradehub_client.active_sentry_api_list)
+
+    def test_tradehub_get_request(self):
+        expect: dict = {
+            "jsonrpc": str,
+            "id": int,
+            "result": {
+                "node_info": {
+                    "protocol_version": {
+                        "p2p": str,
+                        "block":  str,
+                        "app":  str,
+                    },
+                    "id": str,
+                    "listen_addr": str,
+                    "network": str,
+                    "version": str,
+                    "channels": str,
+                    "moniker": str,
+                    "other": {
+                        "tx_index": str,
+                        "rpc_address": str,
+                    }
+                },
+                "sync_info": {
+                    "latest_block_hash": str,
+                    "latest_app_hash": str,
+                    "latest_block_height": str,
+                    "latest_block_time": str,
+                    "earliest_block_hash": str,
+                    "earliest_app_hash": str,
+                    "earliest_block_height": str,
+                    "earliest_block_time": str,
+                    "catching_up": bool
+                },
+                "validator_info": {
+                    "address": str,
+                    "pub_key": {
+                        "type": str,
+                        "value": str,
+                    },
+                    "voting_power": str,
+                }
+            }
+        }
+
+        result = self.tradehub_client.tradehub_get_request(path='/get_status')
+        self.assertDictStructure(expect, result)
+
+        # This Sentry IP should fail and retry with an existing Sentry IP in the active list.
+        self.tradehub_client.active_sentry_api_ip = "116.202.216.145"
+        self.tradehub_client.active_sentry_api_list.append("116.202.216.145")
+        result = self.tradehub_client.tradehub_get_request(path='/get_status')
+        self.assertDictStructure(expect, result)

--- a/tests/test_tradehub_utils.py
+++ b/tests/test_tradehub_utils.py
@@ -1,0 +1,111 @@
+import tradehub.utils as utils
+from tests import APITestCase, NEO_ADDRESS, NEO_CONTRACT, ETH_ADDRESS, ETH_CONTRACT, WEB3_API_URL
+
+
+class TestTradeHubUtils(APITestCase):
+
+    def setUp(self) -> None:
+        self.r = utils.Request(api_url='https://jsonplaceholder.typicode.com/')
+        self.s = utils.Request()
+
+    def test_request_get(self):
+        json_msg = {
+            "userId": 1,
+            "id": 1,
+            "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+            "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"}
+        self.assertDictEqual(self.r.get(path='/posts/1'), json_msg)
+
+    def test_request_post(self):
+        json_dict = {
+            'title': 'foo',
+            'body': 'bar',
+            'userId': 1}
+        json_msg = {
+            'id': 101,
+            'title': 'foo',
+            'body': 'bar',
+            'userId': 1}
+        self.assertDictEqual(self.r.post(path='/posts', json_data=json_dict), json_msg)
+
+    def test_request_status(self):
+        expect: dict = {
+            "jsonrpc": str,
+            "id": int,
+            "result": {
+                "node_info": {
+                    "protocol_version": {
+                        "p2p": str,
+                        "block":  str,
+                        "app":  str,
+                    },
+                    "id": str,
+                    "listen_addr": str,
+                    "network": str,
+                    "version": str,
+                    "channels": str,
+                    "moniker": str,
+                    "other": {
+                        "tx_index": str,
+                        "rpc_address": str,
+                    }
+                },
+                "sync_info": {
+                    "latest_block_hash": str,
+                    "latest_app_hash": str,
+                    "latest_block_height": str,
+                    "latest_block_time": str,
+                    "earliest_block_hash": str,
+                    "earliest_app_hash": str,
+                    "earliest_block_height": str,
+                    "earliest_block_time": str,
+                    "catching_up": bool
+                },
+                "validator_info": {
+                    "address": str,
+                    "pub_key": {
+                        "type": str,
+                        "value": str,
+                    },
+                    "voting_power": str,
+                }
+            }
+        }
+
+        self.assertDictStructure(expect, self.s.status())
+
+    def test_sort_and_stringify_json(self):
+        json_msg = {"name": "John Smith", "age": 27, "siblings": ["Jane", "Joe"]}
+        stringify_msg = '{"age":27,"name":"John Smith","siblings":["Jane","Joe"]}'
+        self.assertEqual(utils.sort_and_stringify_json(json_msg), stringify_msg)
+
+    def test_to_tradehub_asset_amount(self):
+        self.assertEqual(utils.to_tradehub_asset_amount(amount=float('123.4567')), '12345670000')
+        self.assertEqual(utils.to_tradehub_asset_amount(amount=float('123.4567'), decimals=16), '1234567000000000000')
+
+    def test_reverse_hex(self):
+        self.assertEqual(utils.reverse_hex('ABCD'), 'CDAB')
+        self.assertEqual(utils.reverse_hex('0000000005f5e100'), '00e1f50500000000')
+
+    def test_is_valid_neo_public_address(self):
+        self.assertTrue(utils.is_valid_neo_public_address(address=NEO_ADDRESS))
+        self.assertFalse(utils.is_valid_neo_public_address(address=NEO_CONTRACT))
+
+    def test_neo_get_scripthash_from_address(self):
+        self.assertEqual(utils.neo_get_scripthash_from_address(address=NEO_ADDRESS), 'fea2b883725ef2d194c9060f606cd0a0468a2c59')
+
+    def test_is_eth_contract(self):
+        self.assertTrue(utils.is_eth_contract(address=ETH_CONTRACT,
+                                              web3_uri=WEB3_API_URL))
+        self.assertFalse(utils.is_eth_contract(address=ETH_ADDRESS,
+                                               web3_uri=WEB3_API_URL))
+
+    def test_format_withdraw_address(self):
+        valid_neo_address = utils.format_withdraw_address(address=NEO_ADDRESS, blockchain='neo')
+        self.assertEqual(valid_neo_address, '592c8a46a0d06c600f06c994d1f25e7283b8a2fe')
+        with self.assertRaises(ValueError):
+            utils.format_withdraw_address(address=NEO_CONTRACT, blockchain='neo')
+        valid_eth_address = utils.format_withdraw_address(address=ETH_ADDRESS, blockchain='eth', web3_uri=WEB3_API_URL)
+        self.assertEqual(valid_eth_address, '32c46323b51c977814E05EF5E258Ee4da0E4c3c3')
+        with self.assertRaises(ValueError):
+            utils.format_withdraw_address(address=ETH_CONTRACT, blockchain='eth', web3_uri=WEB3_API_URL)

--- a/tradehub/authenticated_client.py
+++ b/tradehub/authenticated_client.py
@@ -285,9 +285,9 @@ class AuthenticatedClient(TradehubPublicClient):
         transaction_type = "BEGIN_REDELEGATING_TOKENS_MSG_TYPE"
         return self.submit_transaction_on_chain(messages=[message], transaction_type=transaction_type, fee=fee)
 
-    def create_withdraw(self, message: types.CreateWithdrawMessage, fee: dict = None):
+    def create_withdraw(self, message: types.CreateWithdrawMessage, blockchain: str, fee: dict = None):
         message.fee_address = 'swth1prv0t8j8tqcdngdmjlt59pwy6dxxmtqgycy2h7'
-        message.to_address = format_withdraw_address(address=message.to_address)
+        message.to_address = format_withdraw_address(address=message.to_address, blockchain=blockchain)
         transaction_type = "CREATE_WITHDRAWAL_TYPE"
         return self.submit_transaction_on_chain(messages=[message], transaction_type=transaction_type, fee=fee)
 

--- a/tradehub/decentralized_client.py
+++ b/tradehub/decentralized_client.py
@@ -1,0 +1,153 @@
+import multiprocessing as mp
+from tradehub.utils import Request
+import random
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+import threading
+
+
+class TradehubNodeClient(object):
+
+    def __init__(self, network: str = "testnet"):
+        if network.lower() not in ["main", "mainnet", "test", "testnet"]:
+            raise ValueError("Parameter network - {} - is not valid, requires main, mainnent, test, or testnet.".format(network))
+
+        self.seed_peers_list = {
+            "main": ["54.255.5.46", "175.41.151.35"],
+            "mainnet": ["54.255.5.46", "175.41.151.35"],
+            "test": ["54.255.42.175", "52.220.152.108"],
+            "testnet": ["54.255.42.175", "52.220.152.108"],
+        }
+        self.tradescan_node_url = {
+            "main": "https://switcheo.org/nodes?net=main",
+            "mainnet": "https://switcheo.org/nodes?net=main",
+            "test": "https://switcheo.org/nodes?net=test",
+            "testnet": "https://switcheo.org/nodes?net=test",
+        }
+
+        self.all_peers_list = self.seed_peers_list[network.lower()]
+        self.active_validator_list = []
+        self.active_sentry_api_list = []
+        self.validator_crawler_mp()
+        self.sentry_status_request()
+        self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
+
+    def validator_crawler_mp(self):
+        checked_peers_list = []
+        unchecked_peers_list = list(set(self.all_peers_list) - set(checked_peers_list))
+
+        while unchecked_peers_list:
+
+            pool = mp.Pool(processes=10)
+            validator_outputs = pool.map(self.validator_status_request, unchecked_peers_list)
+            pool.close()
+            pool.join()
+
+            for validator in validator_outputs:
+                self.all_peers_list.append(validator["ip"])
+                checked_peers_list.append(validator["ip"])
+                if validator["validator_status"] == "Active" and not validator["catching_up"]:
+                    self.active_validator_list.append(validator["ip"])
+                for connected_node in validator["connected_nodes"]:
+                    self.all_peers_list.append(connected_node["node_ip"])
+
+            self.all_peers_list = list(dict.fromkeys(self.all_peers_list))
+            checked_peers_list = list(dict.fromkeys(checked_peers_list))
+            self.active_validator_list = list(dict.fromkeys(self.active_validator_list))
+            unchecked_peers_list = list(set(self.all_peers_list) - set(checked_peers_list))
+
+            # If the initial peers do not return any reults, query Tradescan API.
+            # if not self.active_peers_list:
+            #     validators = Request(api_url=self.tradescan_node_url, timeout=30).get()
+            #     for validator in validators:
+            #         unchecked_peers_list.append(validator["ip"])
+
+    def validator_status_request(self, validator_ip):
+        validator_status = {}
+        try:
+            process_peer = True
+            validator_status["ip"] = validator_ip
+            i = Request(api_url="http://{}:26657".format(validator_ip), timeout=1).get(path='/net_info')
+        except (ValueError, ConnectionError, HTTPError, Timeout) as e:
+            validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Validator INFO - {}".format(e)
+            validator_status["connected_nodes"] = []
+            process_peer = False
+
+        if process_peer:
+            connected_nodes = []
+
+            for connected_peer in i["result"]["peers"]:
+                connected_nodes.append({
+                    "node_id": connected_peer["node_info"]["id"],
+                    "node_ip": connected_peer["remote_ip"],
+                    "node_full": "{}@{}".format(connected_peer["node_info"]["id"], connected_peer["remote_ip"])
+                })
+
+            try:
+                s = Request(api_url="http://{}:26657".format(validator_ip), timeout=1).get(path='/status')
+            except (ValueError, ConnectionError, HTTPError, Timeout) as e:
+                validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Status end point - {}".format(e)
+                validator_status["connected_nodes"] = []
+                process_peer = False
+
+            if process_peer:
+                validator_status = self.parse_validator_status(request_json=s, validator_ip=validator_ip)
+                validator_status["validator_status"] = "Active"
+                validator_status["connected_nodes"] = connected_nodes
+
+        return validator_status
+
+    def parse_validator_status(self, request_json, validator_ip):
+        return {
+            "moniker": request_json["result"]["node_info"]["moniker"],
+            "id": request_json["result"]["node_info"]["id"],
+            "ip": validator_ip,
+            "version": request_json["result"]["node_info"]["version"],
+            "network": request_json["result"]["node_info"]["network"],
+            "latest_block_hash": request_json["result"]["sync_info"]["latest_block_hash"],
+            "latest_block_height": request_json["result"]["sync_info"]["latest_block_height"],
+            "latest_block_time": request_json["result"]["sync_info"]["latest_block_time"],
+            "earliest_block_height": request_json["result"]["sync_info"]["earliest_block_height"],
+            "earliest_block_time": request_json["result"]["sync_info"]["earliest_block_time"],
+            "catching_up": request_json["result"]["sync_info"]["catching_up"],
+            "validator_address": request_json["result"]["validator_info"]["address"],
+            "validator_pub_key_type": request_json["result"]["validator_info"]["pub_key"]["type"],
+            "validator_pub_key": request_json["result"]["validator_info"]["pub_key"]["value"],
+            "validator_voting_power": request_json["result"]["validator_info"]["voting_power"]
+        }
+
+    def sentry_status_request(self):
+        for active_validator in self.active_validator_list:
+            try:
+                Request(api_url="http://{}:5001".format(active_validator), timeout=1).get(path='/get_status')
+                self.active_sentry_api_list.append(active_validator)
+            except (ValueError, ConnectionError, HTTPError, Timeout):
+                pass
+        self.active_sentry_api_list = list(dict.fromkeys(self.active_sentry_api_list))
+
+    def update_validators_and_sentries(self):
+        threading.Timer(5.0, self.update_validators_and_sentries).start()
+        self.validator_crawler_mp()
+        self.sentry_status_request()
+        self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
+
+    def tradehub_get_request(self, path: str, params=None):
+        try:
+            req = Request(api_url="http://{}:5001".format(self.active_sentry_api_ip), timeout=2).get(path=path, params=params)
+            return req
+        except (ValueError, ConnectionError, HTTPError, Timeout):
+            self.active_sentry_api_list.remove(self.active_sentry_api_ip)
+            if not self.active_sentry_api_list:
+                self.validator_crawler_mp()
+                self.sentry_status_request()
+            self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
+
+    def tradehub_post_request(self, path: str, data=None, json_data=None, params=None):
+        try:
+            req = Request(api_url="http://{}:5001".format(self.active_sentry_api_ip), timeout=2).post(self, path=path, data=data, json_data=json_data, params=params)
+            return req
+        except (ValueError, ConnectionError, HTTPError, Timeout):
+            self.active_sentry_api_list.remove(self.active_sentry_api_ip)
+            if not self.active_sentry_api_list:
+                self.validator_crawler_mp()
+                self.sentry_status_request()
+            self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]

--- a/tradehub/decentralized_client.py
+++ b/tradehub/decentralized_client.py
@@ -140,6 +140,7 @@ class TradehubNodeClient(object):
                 self.validator_crawler_mp()
                 self.sentry_status_request()
             self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
+            return self.tradehub_get_request(path=path, params=params)
 
     def tradehub_post_request(self, path: str, data=None, json_data=None, params=None):
         try:
@@ -151,3 +152,4 @@ class TradehubNodeClient(object):
                 self.validator_crawler_mp()
                 self.sentry_status_request()
             self.active_sentry_api_ip = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
+            return self.tradehub_post_request(path=path, data=data, json_data=json_data, params=params)

--- a/tradehub/public_client.py
+++ b/tradehub/public_client.py
@@ -1478,7 +1478,7 @@ class PublicClient(object):
         return self.request.get(path='/get_trades', params=api_params)
 
     def get_transactions_fees(self):
-        gas_fees = self.request.get(path = '/get_txns_fees')
+        gas_fees = self.request.get(path='/get_txns_fees')
         fees = {}
         for gas_fee in gas_fees["result"]:
             fees[gas_fee["msg_type"]] = gas_fee["fee"]

--- a/tradehub/utils.py
+++ b/tradehub/utils.py
@@ -2,7 +2,6 @@ import base58
 import binascii
 import json
 import math
-import multiprocessing as mp
 import requests
 from web3 import Web3
 
@@ -17,7 +16,7 @@ class TradehubApiException(Exception):
 
 class Request(object):
 
-    def __init__(self, api_url='https://switcheo.org', timeout=30):
+    def __init__(self, api_url='https://test-tradescan.switcheo.org', timeout=30):
         self.url = api_url.rstrip('/')
         self.timeout = timeout
 
@@ -37,9 +36,7 @@ class Request(object):
         return r.json()
 
     def status(self):
-        r = requests.get(url=self.url)
-        r.raise_for_status()
-        return r.json()
+        return self.get(path='/get_status')
 
 
 def sort_and_stringify_json(message):
@@ -50,244 +47,13 @@ def sort_and_stringify_json(message):
     """
     return json.dumps(message, sort_keys=True, separators=(',', ':'))
 
-# def validator_crawler(network = 'test'):
-#     peers_dict = {}
-#     all_peers_list = []
-#     checked_peers_list = []
-#     active_peers_list = []
-#     continue_checking_peers = True
-#     seed_peers_list = {
-#         "main": ["54.255.5.46", "168.119.70.59", "192.99.247.238", "40.87.48.237", "18.141.90.114"],
-#         "test": ["54.255.42.175", "52.220.152.108"]
-#     }
-
-#     if network in ["main", "test"]:
-#         all_peers_list = seed_peers_list[network]
-
-#     while continue_checking_peers:
-#         unchecked_peers_list = list(set(all_peers_list) - set(checked_peers_list))
-#         print("Unchecked Peers: {}".format(unchecked_peers_list))
-#         for peer in unchecked_peers_list:
-#             print(peer)
-#             try:
-#                 process_peer = True
-#                 i = requests.get("http://{}:26657/net_info".format(peer), timeout=1)
-#             except requests.exceptions.Timeout:
-#                 print("{} timed out on net_info.".format(peer))
-#                 peers_dict[peer] = {
-#                     "validator_status": "Unknown - Cannot Connect to Retrieve Validator INFO",
-#                     "connected_nodes": []
-#                 }
-#                 process_peer = False
-#             except requests.exceptions.ConnectionError:
-#                 print("{} Connection Error; max retries exceeded with url: net_info.".format(peer))
-#                 peers_dict[peer] = {
-#                     "validator_status": "Unknown - Cannot Connect to Retrieve Validator INFO",
-#                     "connected_nodes": []
-#                 }
-#                 process_peer = False
-
-#             all_peers_list.append(peer)
-#             checked_peers_list.append(peer)
-#             if i.status_code == 200 and process_peer:
-#                 connected_nodes = []
-
-#                 for connected_peer in i.json()["result"]["peers"]:
-#                     all_peers_list.append(connected_peer["remote_ip"])
-#                     connected_nodes.append({
-#                         "node_id": connected_peer["node_info"]["id"],
-#                         "node_ip": connected_peer["remote_ip"],
-#                         "node_full": "{}@{}".format(connected_peer["node_info"]["id"], connected_peer["remote_ip"])
-#                     })
-#
-#                 try:
-#                     s = requests.get("http://{}:26657/status".format(peer))
-#                 except requests.exceptions.Timeout:
-#                     print("{} timed out on status.".format(peer))
-#                     peers_dict[peer] = {
-#                         "validator_status": "Unknown - Cannot Connect to Retrieve Status end point",
-#                         "connected_nodes": []
-#                     }
-#                     process_peer = False
-#                 except requests.exceptions.ConnectionError:
-#                     print("{} Connection Error; max retries exceeded with url: status.".format(peer))
-#                     peers_dict[peer] = {
-#                         "validator_status": "Unknown - Cannot Connect to Retrieve Status end point",
-#                         "connected_nodes": []
-#                     }
-#                     process_peer = False
-#
-#                 if s.status_code == 200 and process_peer:
-#                     peers_dict[peer] = parse_validator_status(request_json = s.json())
-#                     peers_dict["validator_status"] = "Active"
-#                     peers_dict["connected_nodes"] = connected_nodes
-#                     if not peers_dict[peer]["catching_up"]:
-#                         active_peers_list.append(peer)
-#
-#                 all_peers_list = list(dict.fromkeys(all_peers_list))
-#                 checked_peers_list = list(dict.fromkeys(checked_peers_list))
-#                 active_peers_list = list(dict.fromkeys(active_peers_list))
-#
-#         unchecked_peers_list = list(set(all_peers_list) - set(checked_peers_list))
-#         print("Unchecked Peers: {}".format(unchecked_peers_list))
-#         if not unchecked_peers_list and active_peers_list:
-#             continue_checking_peers = False
-#         elif not unchecked_peers_list and not active_peers_list:
-#             validators = Request(api_url = 'https://tradescan.switcheo.org', timeout = 30).get(path = '/monitor')
-#             for validator in validators:
-#                 unchecked_peers_list.append(validator["ip"])
-#
-#     peers_dict["active_peers"] = active_peers_list
-#     # print(peers_dict)
-#     # print(peers_dict["active_peers"])
-
-
-def validator_crawler_mp(network: str = 'test'):
-    if network.lower() not in ["main", "mainnet", "test", "testnet"]:
-        raise ValueError("Parameter network - {} - is not valid, requires main, mainnent, test, or testnet.".format(network))
-
-    peers_dict = {}
-    all_peers_list = []
-    checked_peers_list = []
-    active_peers_list = []
-    continue_checking_peers = True
-
-    seed_peers_list = {
-        "main": ["54.255.5.46", "175.41.151.35"],
-        "mainnet": ["54.255.5.46", "175.41.151.35"],
-        "test": ["54.255.42.175", "52.220.152.108"],
-        "testnet": ["54.255.42.175", "52.220.152.108"],
-    }
-
-    tradescan_node_url = {
-        "main": "https://switcheo.org/nodes?net=main",
-        "mainnet": "https://switcheo.org/nodes?net=main",
-        "test": "https://switcheo.org/nodes?net=test",
-        "testnet": "https://switcheo.org/nodes?net=test",
-    }
-
-    if network in ["main", "mainnet", "test", "testnet"]:
-        all_peers_list = seed_peers_list[network]
-
-    while continue_checking_peers:
-        unchecked_peers_list = list(set(all_peers_list) - set(checked_peers_list))
-
-        pool = mp.Pool(processes=10)
-        validator_outputs = pool.map(validator_status_request, unchecked_peers_list)
-        pool.close()
-        pool.join()
-
-        for validator in validator_outputs:
-            all_peers_list.append(validator["ip"])
-            checked_peers_list.append(validator["ip"])
-            if validator["validator_status"] == "Active" and not validator["catching_up"]:
-                active_peers_list.append(validator["ip"])
-            for connected_node in validator["connected_nodes"]:
-                all_peers_list.append(connected_node["node_ip"])
-
-        all_peers_list = list(dict.fromkeys(all_peers_list))
-        checked_peers_list = list(dict.fromkeys(checked_peers_list))
-        active_peers_list = list(dict.fromkeys(active_peers_list))
-        unchecked_peers_list = list(set(all_peers_list) - set(checked_peers_list))
-
-        if not unchecked_peers_list and active_peers_list:
-            continue_checking_peers = False
-        elif not unchecked_peers_list and not active_peers_list:
-            validators = Request(api_url=tradescan_node_url, timeout=30).get()
-            for validator in validators:
-                unchecked_peers_list.append(validator["ip"])
-
-    if "116.202.216.145" in active_peers_list:
-        active_peers_list.remove("116.202.216.145")
-    if "135.181.157.127" in active_peers_list:
-        active_peers_list.remove("135.181.157.127")
-    if "135.181.196.133" in active_peers_list:
-        active_peers_list.remove("135.181.196.133")
-    for active_peer in active_peers_list:
-        try:
-            Request(api_url="http://{}:5001".format(active_peer), timeout=1).get(path='/get_status')
-        except requests.exceptions.Timeout or requests.exceptions.ConnectionError:
-            active_peers_list.remove(active_peer)
-
-    peers_dict["active_peers"] = active_peers_list
-    return peers_dict
-
-
-def validator_status_request(validator_ip):
-    validator_status = {}
-    try:
-        process_peer = True
-        validator_status["ip"] = validator_ip
-        i = requests.get("http://{}:26657/net_info".format(validator_ip), timeout=1)
-    except requests.exceptions.Timeout:
-        validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Validator INFO"
-        validator_status["connected_nodes"] = []
-        process_peer = False
-    except requests.exceptions.ConnectionError:
-        validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Validator INFO"
-        validator_status["connected_nodes"] = []
-        process_peer = False
-
-    if process_peer and i.status_code == 200:
-        connected_nodes = []
-
-        for connected_peer in i.json()["result"]["peers"]:
-            connected_nodes.append({
-                "node_id": connected_peer["node_info"]["id"],
-                "node_ip": connected_peer["remote_ip"],
-                "node_full": "{}@{}".format(connected_peer["node_info"]["id"], connected_peer["remote_ip"])
-            })
-
-        try:
-            s = requests.get("http://{}:26657/status".format(validator_ip))
-        except requests.exceptions.Timeout:
-            validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Status end point"
-            validator_status["connected_nodes"] = []
-            process_peer = False
-        except requests.exceptions.ConnectionError:
-            validator_status["validator_status"] = "Unknown - Cannot Connect to Retrieve Status end point"
-            validator_status["connected_nodes"] = []
-            process_peer = False
-
-        if process_peer and s.status_code == 200:
-            validator_status = parse_validator_status(request_json=s.json(), validator_ip=validator_ip)
-            validator_status["validator_status"] = "Active"
-            validator_status["connected_nodes"] = connected_nodes
-        elif process_peer and s.status_code != 200:
-            validator_status["validator_status"] = "Disabled - Status Endpoint - Status code {} received".format(i.status_code)
-            validator_status["connected_nodes"] = []
-            process_peer = False
-
-    elif process_peer and i.status_code != 200:
-        validator_status["validator_status"] = "Disabled - Net Info Endpoint - Status code {} received".format(i.status_code)
-        validator_status["connected_nodes"] = []
-        process_peer = False
-
-    return validator_status
-
-
-def parse_validator_status(request_json, validator_ip):
-    return {
-        "moniker": request_json["result"]["node_info"]["moniker"],
-        "id": request_json["result"]["node_info"]["id"],
-        "ip": validator_ip,
-        "version": request_json["result"]["node_info"]["version"],
-        "network": request_json["result"]["node_info"]["network"],
-        "latest_block_hash": request_json["result"]["sync_info"]["latest_block_hash"],
-        "latest_block_height": request_json["result"]["sync_info"]["latest_block_height"],
-        "latest_block_time": request_json["result"]["sync_info"]["latest_block_time"],
-        "earliest_block_height": request_json["result"]["sync_info"]["earliest_block_height"],
-        "earliest_block_time": request_json["result"]["sync_info"]["earliest_block_time"],
-        "catching_up": request_json["result"]["sync_info"]["catching_up"],
-        "validator_address": request_json["result"]["validator_info"]["address"],
-        "validator_pub_key_type": request_json["result"]["validator_info"]["pub_key"]["type"],
-        "validator_pub_key": request_json["result"]["validator_info"]["pub_key"]["value"],
-        "validator_voting_power": request_json["result"]["validator_info"]["voting_power"]
-    }
-
 
 def to_tradehub_asset_amount(amount: float, decimals: int = 8):
     return "{:.0f}".format(amount * math.pow(10, decimals))
+
+
+def reverse_hex(message: str):
+    return "".join([message[x:x + 2] for x in range(0, len(message), 2)][::-1])
 
 
 def is_valid_neo_public_address(address: str) -> bool:
@@ -305,10 +71,6 @@ def is_valid_neo_public_address(address: str) -> bool:
     return valid
 
 
-def reverse_hex(message: str):
-    return "".join([message[x:x + 2] for x in range(0, len(message), 2)][::-1])
-
-
 def neo_get_scripthash_from_address(address: str):
     hash_bytes = binascii.hexlify(base58.b58decode_check(address))
     return reverse_hex(hash_bytes[2:].decode('utf-8'))
@@ -316,19 +78,20 @@ def neo_get_scripthash_from_address(address: str):
 
 def is_eth_contract(address: str, web3_uri: str):
     eth_w3 = Web3(provider=Web3.HTTPProvider(endpoint_uri=web3_uri))
-    if len(eth_w3.eth.getCode(eth_w3.toChecksumAddress(value=address))) == 0:
-        return True
-    else:
+    if len(eth_w3.eth.get_code(eth_w3.toChecksumAddress(value=address))) == 0:
         return False
+    else:
+        return True
 
 
-def format_withdraw_address(address: str):
-    if is_valid_neo_public_address(address=address):
+def format_withdraw_address(address: str, blockchain: str, web3_uri: str = None):
+    if blockchain.lower() in ['neo'] and is_valid_neo_public_address(address=address):
         return reverse_hex(neo_get_scripthash_from_address(address=address))
-    elif Web3.isAddress(value=address):
-        if is_eth_contract(address=address):
+    elif blockchain.lower() in ['eth', 'ethereum'] and Web3.isAddress(value=address):
+        if is_eth_contract(address=address, web3_uri=web3_uri):
             raise ValueError('Cannot withdraw to an Ethereum contract address.')
         else:
+            print("In Web3")
             return Web3.toChecksumAddress(value=address)[2:]
     else:
-        raise ValueError('Not a valid address or blockchain not yet supported.')
+        raise ValueError('Not a valid address OR blockchain not yet supported.')


### PR DESCRIPTION
This commit has moved the Node Crawler utility from the Utility File into it's own class.

This change allows us to build the node list once and quickly iterate through available nodes until it is exhausted. We can also use a function in here to allow the nodes to update in the background every 5 minutes if there are long running Python processes that need to be sure that there is always a API endpoint available.