### PR TITLE
Removed Cosmos Endpoints, not accessable via the REST(Port 5002)

### DIFF
--- a/tradehub/public_account_client.py
+++ b/tradehub/public_account_client.py
@@ -144,12 +144,6 @@ class PublicClient(PublicBlockchainClient):
         }
         return self.tradehub_get_request(path='/get_address', params=api_params)
 
-    def get_address_rewards(self, address: str):
-        return self.tradehub_get_request(path='/distribution/delegators/{}/rewards'.format(address))
-
-    def get_address_staking(self, address: str):
-        return self.tradehub_get_request(path='/staking/delegators/{}/delegations'.format(address))
-
     def get_address_trades(self, limit: int = 200, pagination: bool = None, address: str = None):
         api_params = {}
         if pagination is not None:


### PR DESCRIPTION
These endpoints are cosmos endpoints and are not available via port 5002