### PR TITLE
Force active_sentry_api_list to be trusted uri/ip list

### DIFF
--- a/tradehub/decentralized_client.py
+++ b/tradehub/decentralized_client.py
@@ -93,11 +93,15 @@ class NetworkCrawlerClient(object):
             self.active_validator_list = trusted_ip_list
             self.active_sentry_api_list = []
             self.sentry_status_request(uri=False)
+            if not self.active_sentry_api_list:
+                self.active_sentry_api_list = trusted_ip_list
         elif trusted_uri_list:
             self.all_peers_list = trusted_uri_list
             self.active_validator_list = trusted_uri_list
             self.active_sentry_api_list = []
             self.sentry_status_request(uri=True)
+            if not self.active_sentry_api_list:
+                self.active_sentry_api_list = trusted_uri_list
         self.active_sentry_uri = self.active_sentry_api_list[random.randint(a=0, b=len(self.active_sentry_api_list)-1)]
         self.active_sentry_api_ip = self.active_sentry_uri.split(':')[1][2:]
         if self.is_websocket_client:


### PR DESCRIPTION
Setup:

Personal Server only port 5000(ws) and 5002(rest) open. I want to force that this server is selected. Port 5001(Reverse Proxy) is closed. This means that the sentry_status_request won't return any open server.