### PR TITLE
Bugfix/error 19

### DIFF
--- a/tradehub/decentralized_client.py
+++ b/tradehub/decentralized_client.py
@@ -349,7 +349,8 @@ class NetworkCrawlerClient(object):
             req = Request(api_url=self.active_sentry_uri, timeout=2).get(path=path, params=params)
             return req
         except (ValueError, ConnectionError, HTTPError, Timeout):
-            self.active_sentry_api_list.remove(self.active_sentry_uri)
+            if self.active_sentry_uri in self.active_sentry_api_list:
+                self.active_sentry_api_list.remove(self.active_sentry_uri)
             if not self.active_sentry_api_list and not self.BYPASS_NETWORK_CRAWLER:
                 self.validator_crawler_mp()
                 self.sentry_status_request()
@@ -373,10 +374,11 @@ class NetworkCrawlerClient(object):
         :return: Dictionary of the return request based on the network path sent.
         """
         try:
-            req = Request(api_url=self.active_sentry_uri, timeout=2).post(path=path, data=data, json_data=json_data, params=params)
+            req = Request(api_url=self.active_sentry_uri, timeout=30).post(path=path, data=data, json_data=json_data, params=params)
             return req
-        except (ValueError, ConnectionError, HTTPError, Timeout):
-            self.active_sentry_api_list.remove(self.active_sentry_uri)
+        except (ValueError, ConnectionError, HTTPError, Timeout) as e:
+            if self.active_sentry_uri in self.active_sentry_api_list:
+                self.active_sentry_api_list.remove(self.active_sentry_uri)
             if not self.active_sentry_api_list and not self.BYPASS_NETWORK_CRAWLER:
                 self.validator_crawler_mp()
                 self.sentry_status_request()

--- a/tradehub/transactions.py
+++ b/tradehub/transactions.py
@@ -53,6 +53,16 @@ class Transactions(TradehubPublicClient):
         self.gas = "100000000000"  # Need to automate
         self.tokens = self.get_token_details()
 
+    def update_account_details(self) -> None:
+        """
+        Triggers an update to fetch current sequence number.
+
+        :return: None
+        """
+        self.account_blockchain_dict = self.get_account_details()
+        self.account_nbr = self.account_blockchain_dict["result"]["value"]["account_number"]
+        self.account_sequence_nbr = self.account_blockchain_dict["result"]["value"]["sequence"]
+
     def get_account_details(self):
         """
         Retrieve Wallet account details required for submitting transactions on Tradehub.

--- a/tradehub/websocket_client.py
+++ b/tradehub/websocket_client.py
@@ -942,6 +942,17 @@ class DemexWebsocket:
         """
         await self._websocket.send(json.dumps(data))
 
+    def open(self) -> bool:
+        """
+        Check if the connection is open.
+
+        :return: Bool
+        """
+        if not self._websocket:
+            return False
+
+        return self._websocket.open
+
     async def disconnect(self):
         """
         Safely close the websocket connection.


### PR DESCRIPTION
+ Added websocket connection check
+ Added check to avoid uncaught exception
+ Added method to refetch account sequence number to handle Cosmos Error Code 4 properly
+ Bugfix/Change: Changed request post timeout from 2 sec to 30sec. If a transaction is submitted via request post to a node this process is blocking. The node makes a precheck(if enabled) and broadcasts the transaction in the network. Meanwhile, the connection to the submitter is still open. The node holds this connection until the transaction was validated/denied by a validator. This whole process can take few seconds. The timeout caused that the sender does not receive a response, but the transaction may be submitted successfully. If the sender retried(automatically done by the Python API Wrapper) the transaction with this nonce(account sequence number) was the same. This caused COSMOS Error Code 19 - Transaction already in Mempool.